### PR TITLE
Support top-level .group(:belongs_to_association), returning hash with models as keys

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,10 +2,11 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
+require "active_record"
 require "activerecord/summarize"
+require_relative "../test/test_data" # Test fixtures so there's something to play with
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
+# You can use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
 # require "pry"

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -1,21 +1,73 @@
 require_relative "./test_helper"
 
-class Person < ActiveRecord::Base
-  establish_connection adapter: "sqlite3", database: ":memory:"
-  connection.create_table table_name, force: true do |t|
+database = ":memory:"
+ENV["DATABASE_URL"] = "sqlite3:#{database}"
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: database)
+stdout_logger = Logger.new($stdout)
+# ActiveRecord::Base.logger = stdout_logger # Usually don't want to see all the inserts, but if you're changing them you might
+
+SILLY_WORDS = %w[Abibliophobia Absquatulate Batrachomyomachy Bibble Billingsgate Bloviate Borborygm Boustrophedon Bowyang Brouhaha Bumbershoot Bumfuzzle Canoodle Cantankerous Cattywampus Cockamamie Codswallop Collop Collywobbles Comeuppance Crapulence Donnybrook Doozy Erinaceous Fard Fatuous Flibbertigibbet Fuddy-duddy Gardyloo Gobbledygook Godwottery Gonzo Goombah Gubbins Hobbledehoy Hocus-pocus Impignorate Lickety-split Lollygag Malarkey Mollycoddle Mugwump Namby-pamby Nincompoop Nudiustertian Ornery Pandiculation Pauciloquent Pettifogger Quire Ratoon Rigmarole Shenanigan Sialoquent Skedaddle Smellfungus Snickersnee Snollygoster Snool TroglodyteWabbit Widdershins Xertz Yarborough Zoanthropy]
+COLORS = %w[Red Orange Yellow Green Blue Indigo Violet]
+
+ActiveRecord::Schema.define do
+  create_table :colors, force: true do |t|
+    t.string :name
+  end
+
+  create_table :people, force: true do |t|
     t.string :name
     t.integer :number_of_cats
+    t.belongs_to :favorite_color, foreign_key: {to_table: :colors}
   end
+
+  connection.create_table :clubs, force: true do |t|
+    t.string :name
+  end
+
+  create_join_table :clubs, :people
+end
+
+class Color < ActiveRecord::Base
+  has_many :fans, class_name: "Person"
+end
+
+class Person < ActiveRecord::Base
+  belongs_to :favorite_color, class_name: "Color"
+  has_and_belongs_to_many :clubs
 
   scope :with_long_name, ->(gt: 20) { where("length(#{table_name}.name) > ?", gt) }
 
+  def self.generate_random!
+    create!(
+      name: SILLY_WORDS.sample(2).join(" "),
+      number_of_cats: rand(0..3),
+      favorite_color_id: rand(1..COLORS.length)
+    )
+  end
+end
+
+class Club < ActiveRecord::Base
+  has_and_belongs_to_many :members, class_name: "Person"
+
   SILLY_WORDS = %w[Abibliophobia Absquatulate Batrachomyomachy Bibble Billingsgate Bloviate Borborygm Boustrophedon Bowyang Brouhaha Bumbershoot Bumfuzzle Canoodle Cantankerous Cattywampus Cockamamie Codswallop Collop Collywobbles Comeuppance Crapulence Donnybrook Doozy Erinaceous Fard Fatuous Flibbertigibbet Fuddy-duddy Gardyloo Gobbledygook Godwottery Gonzo Goombah Gubbins Hobbledehoy Hocus-pocus Impignorate Lickety-split Lollygag Malarkey Mollycoddle Mugwump Namby-pamby Nincompoop Nudiustertian Ornery Pandiculation Pauciloquent Pettifogger Quire Ratoon Rigmarole Shenanigan Sialoquent Skedaddle Smellfungus Snickersnee Snollygoster Snool TroglodyteWabbit Widdershins Xertz Yarborough Zoanthropy]
 
-  def self.generate_random!
-    create!(name: SILLY_WORDS.sample(2).join(" "), number_of_cats: rand(0..3))
+  def self.generate_random!(members)
+    create!(name: SILLY_WORDS.sample(2).join(" "), members: members)
   end
+end
+
+Color.transaction do
+  COLORS.each_with_index { |name, i| Color.create(name: name, id: i + 1) }
 end
 
 Person.transaction do
   500.times { Person.generate_random! }
 end
+
+Club.transaction do
+  people = Person.all
+  30.times { Club.generate_random!(people.sample(rand(3..60))) }
+end
+
+# Often helpful to see the queries the tests run
+ActiveRecord::Base.logger = stdout_logger

--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define do
 end
 
 class Color < ActiveRecord::Base
-  has_many :fans, class_name: "Person"
+  has_many :fans, class_name: "Person", foreign_key: :favorite_color_id, inverse_of: :favorite_color
 end
 
 class Person < ActiveRecord::Base

--- a/test/test_summarize.rb
+++ b/test/test_summarize.rb
@@ -115,6 +115,15 @@ class TestSummarize < Minitest::Test
     assert_equal(manual, club_summary)
   end
 
+  def test_belongs_to_model_group_by
+    # Keys are Color models instead of (e.g.) colors.id scalars
+    simple_count = Person.joins(:favorite_color).group(:favorite_color).count
+    summarize_count = Person.joins(:favorite_color).group(:favorite_color).summarize do |people|
+      people.count
+    end
+    assert_equal simple_count, summarize_count
+  end
+
   private
 
   def summarizing(noop: false)


### PR DESCRIPTION
Based upon ActiveRecord's `Model.group(:belongs_to_foo_association).count` returning `{<Foo id:1>=>6, <Foo id:2>=>36}`

Also adds test data and some tests for HABTM use (already stable in practice, just didn't have tests) and loads the test data in `bin/console` for easier development.